### PR TITLE
Make ALLOWED_DOMAINS configurable; tweak/fix env var naming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ AUTH_GOOGLE_ID=abc123.apps.googleusercontent.com # Google API client ID. See htt
 AUTH_GOOGLE_SECRET=abc123 # Google secret from client ID.
 
 GEMINI_API_KEY=abc123 # Gemini API key. See https://ai.google.dev/gemini-api/docs/api-key
-MAX_ROUGH_CHAT_SESSION_SIZE=1048576 # Max approximate size in bytes of a given chat history before it will be reset.
-MAX_CHATS=100 # Max number of active chats. When the limit is reached the least recently active chat will be reset.
+CHRYSALIS_MAX_ROUGH_CHAT_SESSION_SIZE=1048576 # Max approximate size in bytes of a given chat history before it will be reset.
+CHRYSALIS_MAX_CHAT_SESSIONS=100 # Max number of active chat sessions. When the limit is reached the least recently active chat will be reset.
+CHRYSALIS_ALLOWED_DOMAINS=foo.com,bar.org # Optional, comma separated list of domains. If specified, only users at these domains will be allowed to authenticate.
 
 # The ZenHub configuration is only needed for the /zenhub/epic page (under construction), not for the Zenhub Dependency Graph.
 ZENHUB_WORKSPACE_ID=abc123 # The workspace ID needs to be specified for now.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,14 +1,17 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 
-const ALLOWED_DOMAINS = [
-  "techanvil.co.uk",
-  "10up.com",
-  "get10up.com",
-  "google.com",
-];
+const ALLOWED_DOMAINS = process.env.CHRYSALIS_ALLOWED_DOMAINS
+  ? process.env.CHRYSALIS_ALLOWED_DOMAINS.split(",")
+      .map((domain) => domain.trim())
+      .filter(Boolean)
+  : null;
 
 function isAllowedDomain(email: string): boolean {
+  if (ALLOWED_DOMAINS === null) {
+    return true;
+  }
+
   const domain = email.split("@")[1];
   return ALLOWED_DOMAINS.includes(domain);
 }

--- a/src/gemini/chat-factory.ts
+++ b/src/gemini/chat-factory.ts
@@ -13,8 +13,9 @@ import { roughSizeOfObject } from "./utils";
 // } from '@google/generative-ai/server'; // TODO, maybe use context cache for subject data. https://ai.google.dev/gemini-api/docs/caching?lang=node
 
 const MAX_ROUGH_CHAT_SESSION_SIZE =
-  Number(process.env.MAX_ROUGH_CHAT_SESSION_SIZE) || 1024 * 1024; // 1 MiB
-const MAX_CHATS = Number(process.env.MAX_CHAT_SESSIONS) || 100;
+  Number(process.env.CHRYSALIS_MAX_ROUGH_CHAT_SESSION_SIZE) || 1024 * 1024; // 1 MiB
+const MAX_CHAT_SESSIONS =
+  Number(process.env.CHRYSALIS_MAX_CHAT_SESSIONS) || 100;
 
 const API_KEY = process.env.GEMINI_API_KEY;
 
@@ -132,7 +133,7 @@ function checkMaxChatSessions() {
     0
   );
 
-  if (chatCount < MAX_CHATS) {
+  if (chatCount < MAX_CHAT_SESSIONS) {
     console.log("Chat count:", chatCount);
     return;
   }


### PR DESCRIPTION
The list of allowed domains for authentication is now specified by an optional environment variable, `CHRYSALIS_ALLOWED_DOMAINS`.

Additionally, the usage of the variables `MAX_ROUGH_CHAT_SESSION_SIZE` and `MAX_CHAT_SESSIONS` has been tweaked/fixed.

Addresses https://github.com/techanvil/chrysalis/issues/1.